### PR TITLE
Migrate to slugged routes

### DIFF
--- a/getStaticProps.js
+++ b/getStaticProps.js
@@ -103,6 +103,7 @@ export default function createStaticProps(swingsetOptions = {}) {
       activeComponentName,
       componentNames: components.map(({ componentName }) => componentName),
       ...pageProps,
+      mdx,
     }
   }
 }

--- a/getStaticProps.js
+++ b/getStaticProps.js
@@ -7,92 +7,102 @@ import renderToString from 'next-mdx-remote/render-to-string'
 import createScope from './utils/create-scope'
 import components from './__swingset_components'
 
+export function createStaticPaths(swingsetOptions = {}) {
+  return async function getStaticPaths() {
+    // const componentPaths = components.map(({ componentName }) => ({
+    //   params: {
+    //     component: componentName,
+    //   }
+    // }))
+
+    const componentPaths = [
+      {
+        params: { component: 'Accordion' },
+      },
+      {
+        params: { component: 'GridList' },
+      },
+    ]
+
+    console.log('componentPaths:')
+    console.log(componentPaths)
+    return {
+      paths: componentPaths,
+      fallback: false,
+    }
+  }
+}
+
 // TODO: this whole thing honestly needs a refactor
 export default function createStaticProps(swingsetOptions = {}) {
   return async function getStaticProps({ params }) {
     const activeComponentName = params.component
-    // Go through each component, read and format the docs and props files' content
-    const docsSrcs = Object.keys(components).map((name) => {
-      const component = components[name]
-      // Read the docs file, separate content from frontmatter
-      const { content, data } = matter(
-        fs.readFileSync(component.docsPath, 'utf8')
-      )
-      //  Read and parse the component's package.json, if possible
-      const pathToPackageJson = path.join(component.path, 'package.json')
-      const packageJson = existsSync(pathToPackageJson)
-        ? JSON.parse(fs.readFileSync(pathToPackageJson, 'utf8'))
-        : null
 
-      // Check for a file called 'props.json5' - if it exists, we import it as `props`
-      // to the mdx file. This is a nice pattern for knobs and props tables.
-      const propsContent =
-        existsSync(component.propsPath) &&
-        fs.readFileSync(component.propsPath, 'utf8')
+    const component = components[activeComponentName]
 
-      return {
-        frontMatter: data,
-        props: propsContent,
-        propsPath: component.propsPath,
-        packageJson,
-        // Automatically inject a primary headline containing the component's name
-        content: `# \`<${data.componentName}>\` Component\n${content}`,
-      }
-    })
+    // Read the docs file, separate content from frontmatter
+    const { content, data } = matter(
+      fs.readFileSync(component.docsPath, 'utf8')
+    )
+    //  Read and parse the component's package.json, if possible
+    const pathToPackageJson = path.join(component.path, 'package.json')
+    const packageJson = existsSync(pathToPackageJson)
+      ? JSON.parse(fs.readFileSync(pathToPackageJson, 'utf8'))
+      : null
 
-    const mdxSources = await Promise.all(
-      docsSrcs.map(
-        ({ content, frontMatter, props, propsPath, packageJson }) => {
-          const name = frontMatter.componentName
+    // Check for a file called 'props.json5' - if it exists, we import it as `props`
+    // to the mdx file. This is a nice pattern for knobs and props tables.
+    const propsContent =
+      existsSync(component.propsPath) &&
+      fs.readFileSync(component.propsPath, 'utf8')
 
-          // First, we need to get the actual component source
-          const Component = components[name].src
+    const pageProps = {
+      frontMatter: data,
+      props: propsContent,
+      propsPath: component.propsPath,
+      packageJson,
+      // Automatically inject a primary headline containing the component's name
+      content: `# \`<${data.componentName}>\` Component\n${content}`,
+    }
 
-          let peerComponents = {}
-          if (frontMatter.peerComponents) {
-            frontMatter.peerComponents.forEach((name) => {
-              const { src } = components[name]
-              if (!src) {
-                console.warn(`${frontMatter.componentName} lists ${name} as a peerComponent but <${name} /> is not in scope`)
-              } else {
-                peerComponents = Object.assign(peerComponents, {
-                  [name]: src,
-                })
-              }
-            })
-          }
+    // First, we need to get the actual component source
+    const Component = component.src
 
-          // Next, we render the content, passing as the second argument a "scope" object, which contains
-          // our component and some additional presentational components that are made available in the mdx file.
-          return renderToString(content, {
-            components: createScope({ [name]: Component }, swingsetOptions, peerComponents),
-            scope: {
-              componentProps: props
-                ? requireFromString(props, propsPath)
-                : null,
-              packageJson,
-            },
-            mdxOptions: swingsetOptions.mdxOptions || {},
-          }).then((res) => [name, res])
-          // transform to an object for easier name/component mapping on the client side
+    let peerComponents = {}
+    if (data.peerComponents) {
+      data.peerComponents.forEach((name) => {
+        const { src } = components[name]
+        if (!src) {
+          console.warn(
+            `${frontMatter.componentName} lists ${name} as a peerComponent but <${name} /> is not in scope`
+          )
+        } else {
+          peerComponents = Object.assign(peerComponents, {
+            [name]: src,
+          })
         }
-      )
-    ).then((res) => {
-      return res.reduce((m, [name, result]) => {
-        m[name] = result
-        return m
-      }, {})
+      })
+    }
+
+    // Next, we render the content, passing as the second argument a "scope" object, which contains
+    // our component and some additional presentational components that are made available in the mdx file.
+    const mdx = await renderToString(content, {
+      components: createScope(
+        { [activeComponentName]: Component },
+        swingsetOptions,
+        peerComponents
+      ),
+      scope: {
+        componentProps: propsContent ? requireFromString(propsContent, component.propsPath) : null,
+        packageJson,
+      },
+      mdxOptions: swingsetOptions.mdxOptions || {},
     })
 
-    // We need to return both `mdxSources` and `docsSources` so that we have both the component and it's name,
-    // which is used to render the sidebar. We remove the `content` from docsSrcs though since it's not needed,
-    // to prevent a lot of extra useless data from going over the wire.
     return {
-      props: {
-        mdxSources,
-        componentNames: docsSrcs.map((d) => d.frontMatter.componentName),
-        activeComponentName,
-      },
+      activeComponentName,
+      componentNames: components.map(({ componentName }) => componentName),
+      ...pageProps,
     }
   }
 }

--- a/getStaticProps.js
+++ b/getStaticProps.js
@@ -9,23 +9,12 @@ import components from './__swingset_components'
 
 export function createStaticPaths(swingsetOptions = {}) {
   return async function getStaticPaths() {
-    // const componentPaths = components.map(({ componentName }) => ({
-    //   params: {
-    //     component: componentName,
-    //   }
-    // }))
+    const componentPaths = Object.keys(components).map((component) => ({
+      params: {
+        component,
+      }
+    }))
 
-    const componentPaths = [
-      {
-        params: { component: 'Accordion' },
-      },
-      {
-        params: { component: 'GridList' },
-      },
-    ]
-
-    console.log('componentPaths:')
-    console.log(componentPaths)
     return {
       paths: componentPaths,
       fallback: false,
@@ -100,10 +89,12 @@ export default function createStaticProps(swingsetOptions = {}) {
     })
 
     return {
-      activeComponentName,
-      componentNames: components.map(({ componentName }) => componentName),
-      ...pageProps,
-      mdx,
+      props: {
+        activeComponentName,
+        componentNames: Object.keys(components),
+        ...pageProps,
+        mdx,
+      },
     }
   }
 }

--- a/page.jsx
+++ b/page.jsx
@@ -8,7 +8,7 @@ import { useRestoreUrlState, setUrlState } from './utils/url-state'
 import components from './__swingset_components'
 
 export default function createPage(swingsetOptions = {}) {
-  return function Page({ mdxSources, componentNames, activeComponentName }) {
+  return function Page({ componentNames, activeComponentName, mdx }) {
     console.log(`${activeComponentName} page`)
 
     // tracks the name of the current component
@@ -80,7 +80,7 @@ export default function createPage(swingsetOptions = {}) {
     }
 
     // fully hydrated mdx document, with the components in the created scope available for use
-    const mdx = hydrate(mdxSources[name], {
+    const hydratedMdx = hydrate(mdx, {
       components: createScope({ [name]: Component }, swingsetOptions, peerComponents),
     })
 
@@ -133,7 +133,7 @@ export default function createPage(swingsetOptions = {}) {
               ⚠️ Component "{componentNotFound}" was not found
             </p>
           )}
-          {mdx}
+          {hydratedMdx}
         </div>
       </div>
     )


### PR DESCRIPTION
Moves from querystring based navigation to slug-based. so instead of having `pages/components.jsx` that's accessed like `/components?componentName=Button` you've got `pages/components/[component].jsx` and `/components/Button` URL. Still have some work to do:

* [ ] add a new `slug` attribute, that's just the filename, and use that in the url. `components/button` not `components/Button`.
* [ ] fix bug where components are undefined when you navigate between pages in dev mode. does it happen on a static page too?
* [ ] clean up getStaticProps
* [ ] documentation